### PR TITLE
7/4のプルリクエスト

### DIFF
--- a/src/main/kotlin/com/final/project/Teechear/auth/handler/AuthenticationFailureHandler.kt
+++ b/src/main/kotlin/com/final/project/Teechear/auth/handler/AuthenticationFailureHandler.kt
@@ -27,6 +27,7 @@ class AuthenticationFailureHandler : AuthenticationFailureHandler {
         var errorId = ""
         // ExceptionからエラーIDをセットする
         if (authenticationException is BadCredentialsException) {
+            println(authenticationException.message)
             errorId = "ERR-0001"
         }
 

--- a/src/main/kotlin/com/final/project/Teechear/controller/ArticleController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/ArticleController.kt
@@ -34,10 +34,6 @@ class ArticleController(private val userMapper: UserMapper, private val articleM
     ): String {
         val currentUser = userMapper.findByEmailOrName(principal.name)
         val nowDateTime = LocalDateTime.now()
-        println("article Formの中身")
-        println(articleForm.title)
-        println(articleForm.markdownText)
-        nowDateTime.toq
         val article = Article(articleForm.title, currentUser.id, nowDateTime, articleForm.markdownText)
         articleMapper.insert(article)
         return "redirect:/article/${article.id}"

--- a/src/main/kotlin/com/final/project/Teechear/controller/ArticleController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/ArticleController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import java.security.Principal
 import java.time.LocalDateTime
+import java.util.*
 
 @Controller
 @RequestMapping("/article")
@@ -33,8 +34,7 @@ class ArticleController(private val userMapper: UserMapper, private val articleM
             bindingResult: BindingResult
     ): String {
         val currentUser = userMapper.findByEmailOrName(principal.name)
-        val nowDateTime = LocalDateTime.now()
-        val article = Article(articleForm.title, currentUser.id, nowDateTime, articleForm.markdownText)
+        val article = Article(articleForm.title, currentUser.id, Date(), articleForm.markdownText)
         articleMapper.insert(article)
         return "redirect:/article/${article.id}"
     }

--- a/src/main/kotlin/com/final/project/Teechear/controller/LoginController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LoginController.kt
@@ -3,18 +3,21 @@ package com.final.project.Teechear.controller
 import com.final.project.Teechear.mapper.UserMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import java.security.Principal
 
 @Controller
 class LoginController @Autowired constructor(private val userMapper: UserMapper) {
 
     @GetMapping("/login")
-    fun login(principal: Principal?): String {
+    fun login(principal: Principal?, @RequestParam(value = "error") error: String?, model: Model): String {
         if (principal is Principal) {
             return "redirect:/trend"
         }
-        
+
+        model.addAttribute("hasError", error is String)
         return "login"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
@@ -3,11 +3,13 @@ package com.final.project.Teechear.controller
 import com.final.project.Teechear.domain.User
 import com.final.project.Teechear.mapper.UserMapper
 import com.final.project.Teechear.validate.RegisterForm
+import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.validation.BindingResult
+import org.springframework.validation.FieldError
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -16,7 +18,7 @@ import java.security.Principal
 @Controller
 class RegisterController(private val userMapper: UserMapper) {
     @GetMapping("", "/signup")
-    fun register(model : Model, principal: Principal?): String {
+    fun register(model: Model, principal: Principal?): String {
         if (principal is Principal) {
             return "redirect:/trend"
         }
@@ -29,6 +31,14 @@ class RegisterController(private val userMapper: UserMapper) {
     fun userRegister(
             @Validated registerForm: RegisterForm,
             bindingResult: BindingResult): String {
+        if (userMapper.findByEmail(registerForm.email) is User) {
+            bindingResult.addError(FieldError("uniq exception", "email", "メールアドレスはすでに登録済みです"))
+        }
+
+        if (userMapper.findByAccountName(registerForm.accountName) is User) {
+            bindingResult.addError(FieldError("uniq exception", "accountName", "アカウント名はすでに登録済みです"))
+        }
+
         if (bindingResult.hasErrors()) {
             return "register"
         }

--- a/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
@@ -32,6 +32,7 @@ class RegisterController(private val userMapper: UserMapper) {
             @Validated registerForm: RegisterForm,
             bindingResult: BindingResult): String {
         if (userMapper.findByEmail(registerForm.email) is User) {
+            println(userMapper.findByEmail(registerForm.email))
             bindingResult.addError(FieldError("uniq exception", "email", "メールアドレスはすでに登録済みです"))
         }
 

--- a/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
@@ -38,6 +38,6 @@ class RegisterController(private val userMapper: UserMapper) {
                 registerForm.email,
                 BCryptPasswordEncoder().encode(registerForm.password))
         userMapper.insert(user)
-        return "redirect:/login"
+        return "redirect:/trend"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
@@ -8,6 +8,7 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import java.security.Principal
 
 @Controller
 @RequestMapping("/user")

--- a/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
@@ -1,0 +1,31 @@
+package com.final.project.Teechear.controller
+
+import com.final.project.Teechear.domain.User
+import com.final.project.Teechear.mapper.ArticleMapper
+import com.final.project.Teechear.mapper.UserMapper
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+@RequestMapping("/user")
+class UserController(private val userMapper: UserMapper, private val articleMapper: ArticleMapper) {
+
+    @GetMapping("/{userId}")
+    fun show(@PathVariable("userId") userId: Int, model: Model): String {
+        val user = userMapper.select(userId)
+        val articleList = articleMapper.selectByUserId(userId)
+        val contribution = articleList.sumBy { it.likeCount ?: 0 }
+
+        if (user is User) {
+            model.addAttribute("user", user)
+            model.addAttribute("articleList", articleList)
+            model.addAttribute("contribution", contribution)
+            return "user/show"
+        }
+
+        return "error/404.html"
+    }
+}

--- a/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
@@ -55,6 +55,7 @@ class UserController(private val userMapper: UserMapper, private val articleMapp
 
         val currentUser = obtainCurrentUser(principal.name)
         val copyCurrentUser = currentUser.copy(accountName = userEditForm.accountName, profile = userEditForm.profile)
+
         userMapper.update(copyCurrentUser)
         return "redirect:user/${currentUser.id}"
     }

--- a/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
@@ -3,12 +3,18 @@ package com.final.project.Teechear.controller
 import com.final.project.Teechear.domain.User
 import com.final.project.Teechear.mapper.ArticleMapper
 import com.final.project.Teechear.mapper.UserMapper
+import com.final.project.Teechear.validate.UserEditForm
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import org.springframework.validation.BindingResult
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import java.security.Principal
+import javax.websocket.server.PathParam
 
 @Controller
 @RequestMapping("/user")
@@ -32,12 +38,28 @@ class UserController(private val userMapper: UserMapper, private val articleMapp
 
     @GetMapping("/{userId}/edit")
     fun edit(@PathVariable("userId") userId: Int, model: Model, principal: Principal): String {
-        val currentUser = userMapper.findByEmailOrName(principal.name)
+        val currentUser = obtainCurrentUser(principal.name)
         if (userId != currentUser.id) {
             return "redirect:/trend"
         }
 
-        model.addAttribute("user", currentUser)
+        model.addAttribute("userEditForm", UserEditForm(currentUser?.accountName, currentUser?.profile))
         return "user/edit"
+    }
+
+    @PostMapping("")
+    fun update(@Validated userEditForm: UserEditForm, bindingResult: BindingResult, principal: Principal): String {
+        if (bindingResult.hasErrors()) {
+            return "user/edit"
+        }
+
+        val currentUser = obtainCurrentUser(principal.name)
+        val copyCurrentUser = currentUser.copy(accountName = userEditForm.accountName, profile = userEditForm.profile)
+        userMapper.update(copyCurrentUser)
+        return "redirect:user/${currentUser.id}"
+    }
+
+    private fun obtainCurrentUser(accountName: String): User {
+        return userMapper.findByEmailOrName(accountName)
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
@@ -29,4 +29,15 @@ class UserController(private val userMapper: UserMapper, private val articleMapp
 
         return "error/404.html"
     }
+
+    @GetMapping("/{userId}/edit")
+    fun edit(@PathVariable("userId") userId: Int, model: Model, principal: Principal): String {
+        val currentUser = userMapper.findByEmailOrName(principal.name)
+        if (userId != currentUser.id) {
+            return "redirect:/trend"
+        }
+
+        model.addAttribute("user", currentUser)
+        return "user/edit"
+    }
 }

--- a/src/main/kotlin/com/final/project/Teechear/domain/Article.kt
+++ b/src/main/kotlin/com/final/project/Teechear/domain/Article.kt
@@ -1,9 +1,11 @@
 package com.final.project.Teechear.domain
 
+import java.util.*
+
 data class Article(
         val title: String? = null,
         val userId: Int? = null,
-        val releasedAt: java.time.LocalDateTime? = null,
+        val releasedAt: Date? = null,
         val markdownText: String? = null,
         val id: Int? = null,
         val userAccountName: String? = null,

--- a/src/main/kotlin/com/final/project/Teechear/domain/User.kt
+++ b/src/main/kotlin/com/final/project/Teechear/domain/User.kt
@@ -5,4 +5,5 @@ data class User(
         val emailAddress: String? = null,
         val password: String? = null,
         val profile: String? = null,
-        val id: Int? = null)
+        val id: Int? = null,
+        val articleCount: Int? = null)

--- a/src/main/kotlin/com/final/project/Teechear/mapper/ArticleMapper.kt
+++ b/src/main/kotlin/com/final/project/Teechear/mapper/ArticleMapper.kt
@@ -20,4 +20,6 @@ interface ArticleMapper {
      * TODO 全文検索をしたい(タグも含め)
      */
     fun search(query: String): List<Article>
+
+    fun selectByUserId(userId: Int): List<Article>
 }

--- a/src/main/kotlin/com/final/project/Teechear/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/final/project/Teechear/mapper/UserMapper.kt
@@ -10,15 +10,15 @@ interface UserMapper {
 
     fun select(id: Int): User?
 
-    fun selectByUserName(accountName: String): User
-
     fun selectAll(): List<User>
 
     fun delete(id: Int)
 
     fun update(user: User)
 
-    fun findByEmail(emailAddress: String): User
+    fun findByEmail(emailAddress: String): User?
+
+    fun findByAccountName(accountName: String): User?
 
     fun findByEmailOrName(loginName: String): User
 }

--- a/src/main/kotlin/com/final/project/Teechear/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/final/project/Teechear/mapper/UserMapper.kt
@@ -8,7 +8,7 @@ interface UserMapper {
     
     fun insert(user: User)
 
-    fun select(id: Int): User
+    fun select(id: Int): User?
 
     fun selectByUserName(accountName: String): User
 

--- a/src/main/kotlin/com/final/project/Teechear/validate/UserEditForm.kt
+++ b/src/main/kotlin/com/final/project/Teechear/validate/UserEditForm.kt
@@ -4,8 +4,8 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
 data class UserEditForm(
-        @NotBlank(message = "アカウント名が空です")
-        @Size(min = 4, max = 30, message = "アカウント名は最大4文字以上、30文字以内です")
+        @get:NotBlank(message = "アカウント名が空です")
+        @get:Size(min = 4, max = 30, message = "アカウント名は最大4文字以上、30文字以内です")
         var accountName: String?,
         var profile: String?
 )

--- a/src/main/kotlin/com/final/project/Teechear/validate/UserEditForm.kt
+++ b/src/main/kotlin/com/final/project/Teechear/validate/UserEditForm.kt
@@ -1,0 +1,11 @@
+package com.final.project.Teechear.validate
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class UserEditForm(
+        @NotBlank(message = "アカウント名が空です")
+        @Size(min = 4, max = 30, message = "アカウント名は最大4文字以上、30文字以内です")
+        var accountName: String?,
+        var profile: String?
+)

--- a/src/main/resources/com/final/project/Teechear/mapper/ArticleMapper.xml
+++ b/src/main/resources/com/final/project/Teechear/mapper/ArticleMapper.xml
@@ -7,8 +7,7 @@
     <resultMap id="articleResultMap" type="com.final.project.Teechear.domain.Article">
         <result property="title" column="title"/>
         <result property="userId" column="user_id"/>
-        <result property="releasedAt" column="released_at"
-                typeHandler="org.apache.ibatis.type.LocalDateTimeTypeHandler"/>
+        <result property="releasedAt" column="released_at" />
         <result property="markdownText" column="markdown_text"/>
         <result property="id" column="id"/>
         <result property="userAccountName" column="user_account_name" />

--- a/src/main/resources/com/final/project/Teechear/mapper/ArticleMapper.xml
+++ b/src/main/resources/com/final/project/Teechear/mapper/ArticleMapper.xml
@@ -42,4 +42,17 @@
     <select id="search" resultMap="articleResultMap">
         SELECT *, user.account_name user_account_name FROM article, user WHERE title LIKE CONCAT(#{query}, '%')
     </select>
+
+    <select id="selectByUserId" resultMap="articleResultMap">
+        SELECT
+        article.*,
+        (select COUNT(*) from user_like_article ula where article.id = ula.article_id),
+        user.account_name user_account_name
+        FROM
+        user_like_article, article, user
+        WHERE
+        article.user_id = #{userId}
+        ORDER BY
+        article.released_at desc
+    </select>
 </mapper>

--- a/src/main/resources/com/final/project/Teechear/mapper/UserMapper.xml
+++ b/src/main/resources/com/final/project/Teechear/mapper/UserMapper.xml
@@ -27,10 +27,6 @@
         id = #{id}
     </select>
 
-    <select id="selectByUserName" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">
-        SELECT * FROM user WHERE account_name = #{accountName}
-    </select>
-
     <select id="selectAll" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">
         SELECT * FROM user;
     </select>
@@ -44,7 +40,11 @@
     </update>
 
     <select id="findByEmail" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">
-        SELECT * FROM user WHERE email_address=#{emailAddress}
+        SELECT * FROM user WHERE email_address=#{emailAddress} LIMIT 1
+    </select>
+
+    <select id="findByAccountName" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">
+        SELECT * FROM user WHERE account_name=#{emailAddress} LIMIT 1
     </select>
 
     <select id="findByEmailOrName" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">

--- a/src/main/resources/com/final/project/Teechear/mapper/UserMapper.xml
+++ b/src/main/resources/com/final/project/Teechear/mapper/UserMapper.xml
@@ -5,11 +5,12 @@
 
 <mapper namespace="com.final.project.Teechear.mapper.UserMapper">
     <resultMap id="userResultMap" type="com.final.project.Teechear.domain.User">
-        <result property="accountName" column="account_name" />
-        <result property="emailAddress" column="email_address" />
-        <result property="password" column="password" />
-        <result property="profile" column="profile" />
-        <result property="id" column="id" />
+        <result property="accountName" column="account_name"/>
+        <result property="emailAddress" column="email_address"/>
+        <result property="password" column="password"/>
+        <result property="profile" column="profile"/>
+        <result property="id" column="id"/>
+        <result property="articleCount" column="article_count"/>
     </resultMap>
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="id">
@@ -17,7 +18,13 @@
     </insert>
 
     <select id="select" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">
-        SELECT * FROM user WHERE id = #{id}
+        SELECT
+        *,
+        (SELECT COUNT(*) FROM article WHERE article.user_id = user.id) article_count
+        FROM
+        user
+        WHERE
+        id = #{id}
     </select>
 
     <select id="selectByUserName" resultType="com.final.project.Teechear.domain.User" resultMap="userResultMap">

--- a/src/main/resources/templates/article/show.html
+++ b/src/main/resources/templates/article/show.html
@@ -21,7 +21,7 @@
 <body style="background-color: lightgray;">
 <div class="container" style="background-color: white;">
     <div>
-        <h5>${article?.}</h5>
+        <h5>${article?.userAccountName}</h5>
     </div>
     <h1 th:text="${article?.title}"></h1>
     <div th:text="${article?.markdownText}" id="markdownText" style="display: none;"></div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -21,6 +21,7 @@
 <div class="container login-form">
     <h1 class="text-center">Teechear にログイン</h1>
     <form id="loginForm" method="post" th:action="@{/users/login}">
+        <div th:if="${hasError}" class="alert alert-danger">ユーザー名もしくはパスワードが間違っています</div>
         <div class="form-group">
             <label for="loginNameInput">Email</label>
             <input type="text" class="form-control" id="loginNameInput" placeholder="メールアドレスもしくはユーザー名" name="loginName">

--- a/src/main/resources/templates/search/result.html
+++ b/src/main/resources/templates/search/result.html
@@ -32,7 +32,7 @@
             <td><img src="http://diamond.jp/mwimgs/7/1/400/img_71c53c1d81500a1cf73a4f543e72413f27838.jpg"
                      height="50"
                      width="100"></td>
-            <td th:text="${#dates.format(result.releasedAt)}"></td>
+            <td th:text="|${#dates.format(result.releasedAt, 'yyyy年MM月dd日')}に投稿|"></td>
             <td><h3 th:text="${result.title}"></h3></td>
         </tr>
         </tbody>

--- a/src/main/resources/templates/top/trend.html
+++ b/src/main/resources/templates/top/trend.html
@@ -20,6 +20,10 @@
 <body>
 <h1>Trendページ</h1>
 <a href="/article/new">投稿する</a>
+<form th:action="@{/logout}" method="post">
+    <button class="btn btn-primary">ログアウト</button>
+</form>
+
 <form id="searchForm" method="get" th:action="@{/search}">
 　　　　<input type="text" class="form-control" placeholder="キーワードを入力" name="q">
 </form>

--- a/src/main/resources/templates/user/edit.html
+++ b/src/main/resources/templates/user/edit.html
@@ -3,8 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <title>ユーザー編集画面</title>
+
+    <link rel="stylesheet" type="text/css" media="all" th:href="@{/css/login.css}">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
+          integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+            integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+            crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"
+            integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T"
+            crossorigin="anonymous"></script>
 </head>
 <body>
-<h1 th:text="${user.accountName}"></h1>
+<div class="container">
+    <form method="post" th:action="@{/user}" th:object="${userEditForm}">
+
+        <div class="form-group">
+            <label for="accountNameForm">ユーザー名</label>
+            <input type="text" class="form-control" id="accountNameForm" th:field="*{accountName}">
+            <p th:if="${#fields.hasErrors('accountName')}" th:errors="*{accountName}" class="col-sm-offset-2 text-danger"></p>
+        </div>
+
+        <div class="form-group">
+            <label for="profileForm">自己紹介</label>
+            <textarea class="form-control" id="profileForm" th:field="*{profile}"></textarea>
+            <p th:if="${#fields.hasErrors('profile')}" th:errors="*{profile}" class="col-sm-offset-2 text-danger"></p>
+        </div>
+
+        <div class="button row">
+            <div class="col-md-3">
+                <button type="submit" class="btn submit-button">更新</button>
+            </div>
+        </div>
+    </form>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/user/edit.html
+++ b/src/main/resources/templates/user/edit.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+    <title>ユーザー編集画面</title>
+</head>
+<body>
+<h1 th:text="${user.accountName}"></h1>
+</body>
+</html>

--- a/src/main/resources/templates/user/show.html
+++ b/src/main/resources/templates/user/show.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+    <title>Userpage</title>
+
+    <link rel="stylesheet" type="text/css" media="all" th:href="@{/css/login.css}">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
+          integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+            integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+            crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"
+            integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T"
+            crossorigin="anonymous"></script>
+</head>
+<body>
+<div class="container">
+    <div class="row">
+        <div class="col-md-3">
+            <img src="http://diamond.jp/mwimgs/7/1/400/img_71c53c1d81500a1cf73a4f543e72413f27838.jpg"
+                 height="50"
+                 width="100">
+            <h2 th:text="${user.accountName}"></h2>
+        </div>
+
+        <div class="col-md-9">
+            <table class="table table-condensed">
+                <tbody>
+                <tr>
+                    <td th:text="${user.articleCount}"></td>
+                    <td th:text="${contribution}">
+                </tr>
+                <tr>
+                    <td>item</td>
+                    <td>contribution</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/user/show.html
+++ b/src/main/resources/templates/user/show.html
@@ -40,6 +40,18 @@
                 </tr>
                 </tbody>
             </table>
+
+            <table class="table table-condensed">
+                <tbody th:remove="all-but-first" th:each="result : ${articleList}">
+                <tr>
+                    <td><img src="http://diamond.jp/mwimgs/7/1/400/img_71c53c1d81500a1cf73a4f543e72413f27838.jpg"
+                             height="50"
+                             width="100"></td>
+                    <td th:text="|${#dates.format(result.releasedAt, 'yyyy年MM月dd日')}に投稿|"></td>
+                    <td><h3 th:text="${result.title}"></h3></td>
+                </tr>
+                </tbody>
+            </table>
         </div>
     </div>
 </div>


### PR DESCRIPTION
# 実装したこと
- [x] 検索結果画面、詳細画面、トレンドページにそれぞれ投稿日を表示
- [x] ユーザーページ
- [x] ユーザー編集機能
- [ ] 新規登録後、自動でログイン状態にする
- [x] ログイン失敗した時のメッセージを出力する
- [x] account_nameもしくはemailの登録の際にすでに登録済みの時の処理
そちらのユーザー名はすでに登録されています
そちらのメールアドレスはすでに登録されています

# ThymeleafでSimpleFormatが使えない
javaの組み込みクラスを使えない？？
helperクラスてきなのを作れば使える？？

LocalDateTimeからjava.util.Dateに変更することでthymeleafを扱えるように

# ユーザーページに必要なデータ
- contribution
自分の投稿物についたいいねの数
articleにそれぞれlikeCountを持たせているためそっちで計算
- 自分のarticle
- 自分のarticle数

# 新規登録とログイン処理を同時に行う
/user/loginのエンドポイントにpost送信できれば一番楽だがそうも行かなそう？？
そしたらlogin処理を呼び出すようなメソッドがspring securityにあるのでは？

Spring Securityのログインに使っているクラスを呼び出し、ログイン処理を行わせる
https://qiita.com/alpha_pz/items/dcdbde94f52843f305ab