### PR TITLE
7/11のプルリクエスト

### DIFF
--- a/src/main/kotlin/com/final/project/Teechear/controller/CommentController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/CommentController.kt
@@ -16,6 +16,6 @@ class CommentController(private val commentMapper: CommentMapper) {
     @PostMapping("/create")
     fun create(@Validated commentForm: CommentForm, bindingResult: BindingResult): String {
         commentMapper.insert(Comment(commentForm.userId, commentForm.articleId, commentForm.text))
-        return "redirect:/article/3"
+        return "redirect:/article/${commentForm.articleId}"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/RegisterController.kt
@@ -2,6 +2,7 @@ package com.final.project.Teechear.controller
 
 import com.final.project.Teechear.domain.User
 import com.final.project.Teechear.mapper.UserMapper
+import com.final.project.Teechear.service.UserRegisterService
 import com.final.project.Teechear.validate.RegisterForm
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Controller
@@ -12,15 +13,18 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import java.security.Principal
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.RequestMapping
 
 @Controller
-class RegisterController(private val userMapper: UserMapper) {
+class RegisterController(private val userMapper: UserMapper, private val userRegisterService: UserRegisterService) {
+
     @GetMapping("", "/signup")
     fun register(model: Model, principal: Principal?): String {
         if (principal is Principal) {
-
             return "redirect:/trend"
         }
+
         val registerForm = RegisterForm()
         model.addAttribute("registerForm", registerForm)
         return "register"
@@ -30,15 +34,8 @@ class RegisterController(private val userMapper: UserMapper) {
     fun userRegister(
             @Validated registerForm: RegisterForm,
             bindingResult: BindingResult): String {
-        if (userMapper.findByEmail(registerForm.email) != null) {
-            bindingResult.addError(FieldError("uniq exception", "email", "メールアドレスはすでに登録済みです"))
-        }
 
-        if (userMapper.findByAccountName(registerForm.accountName) != null) {
-            bindingResult.addError(FieldError("uniq exception", "accountName", "アカウント名はすでに登録済みです"))
-        }
-
-        if (bindingResult.hasErrors()) {
+        if (userRegisterService.validation(registerForm, bindingResult).hasErrors()) {
             return "register"
         }
 

--- a/src/main/kotlin/com/final/project/Teechear/controller/SearchController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/SearchController.kt
@@ -1,5 +1,6 @@
 package com.final.project.Teechear.controller
 
+import com.final.project.Teechear.domain.Article
 import com.final.project.Teechear.mapper.ArticleMapper
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -13,9 +14,14 @@ class SearchController(private val articleMapper: ArticleMapper) {
 
     @GetMapping("")
     fun search(model: Model, @RequestParam(value = "q") query: String): String {
-        model.addAttribute("articleList", articleMapper.search(query))
+        if (query.isNotEmpty()) {
+            model.addAttribute("articleList", articleMapper.search(query))
+
+        } else {
+            model.addAttribute("articleList", emptyList<Article>())
+        }
+        ArrayList<String>().isEmpty()
         model.addAttribute("query", query)
-        println(articleMapper.search(query))
         return "search/result"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/UserController.kt
@@ -40,7 +40,7 @@ class UserController(private val userMapper: UserMapper, private val articleMapp
 
     @GetMapping("/mypage")
     fun mypage(principal: Principal): String {
-        val currentUser = userMapper.findByEmailOrName("zzzzz")
+        val currentUser = userMapper.findByEmailOrName(principal.name)
         return "redirect:/user/" + currentUser?.id
     }
 

--- a/src/main/kotlin/com/final/project/Teechear/service/UserRegisterService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/UserRegisterService.kt
@@ -1,0 +1,19 @@
+package com.final.project.Teechear.service
+
+import com.final.project.Teechear.mapper.UserMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class UserRegisterService(private val userMapper: UserMapper) {
+
+    fun validation(email: String, accountName: String) {
+        if (userMapper.findByEmailOrName(email) != null) {
+            // TODO メールアドレスがユーザー名もしくはEmailとして登録済みであることのExceptionを発生させる
+        }
+
+        if (userMapper.findByEmailOrName(accountName) != null) {
+            // TODO ユーザー名がユーザー名もしくはEmailとしてすでに
+        }
+    }
+}

--- a/src/main/kotlin/com/final/project/Teechear/service/UserRegisterService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/UserRegisterService.kt
@@ -1,19 +1,26 @@
 package com.final.project.Teechear.service
 
 import com.final.project.Teechear.mapper.UserMapper
+import com.final.project.Teechear.validate.RegisterForm
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.validation.BindingResult
+import org.springframework.validation.FieldError
+import sun.jvm.hotspot.asm.Register
+import javax.naming.Binding
 
 @Service
 class UserRegisterService(private val userMapper: UserMapper) {
 
-    fun validation(email: String, accountName: String) {
-        if (userMapper.findByEmailOrName(email) != null) {
-            // TODO メールアドレスがユーザー名もしくはEmailとして登録済みであることのExceptionを発生させる
+    fun validation(registerForm: RegisterForm, bindingResult: BindingResult): BindingResult {
+        if (userMapper.findByEmail(registerForm.email) != null) {
+            bindingResult.addError(FieldError("uniq exception", "email", "メールアドレスはすでに登録済みです"))
         }
 
-        if (userMapper.findByEmailOrName(accountName) != null) {
-            // TODO ユーザー名がユーザー名もしくはEmailとしてすでに
+        if (userMapper.findByAccountName(registerForm.accountName) != null) {
+            bindingResult.addError(FieldError("uniq exception", "accountName", "アカウント名はすでに登録済みです"))
         }
+
+        return bindingResult
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/validate/RegisterForm.kt
+++ b/src/main/kotlin/com/final/project/Teechear/validate/RegisterForm.kt
@@ -2,11 +2,13 @@ package com.final.project.Teechear.validate
 
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
 import javax.validation.constraints.Size
 
 data class RegisterForm (
     @get:NotBlank(message = "このフィールドを入力してください")
     @get:Size(min = 4, max = 30, message = "4文字以上30文字以内で入力してください")
+    @get:Pattern(regexp = "^[a-zA-Z0-9\\-]+$", message = "ユーザ名は半角英数字及びハイフンのみ利用可能です")
     var accountName: String = "",
 
     @get:NotBlank(message = "このフィールドを入力してください")

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -30,7 +30,7 @@
                 <a class="navbar-brand" href="/trend">TeecHear</a>
                 <form class="navbar-form" action="/search">
                     <div>
-                        <input type="text" class="form-control" placeholder="キーワード" name="q">
+                        <input type="text" class="form-control" placeholder="キーワード" name="q" required>
                     </div>
                 </form>
 

--- a/src/main/resources/templates/search/result.html
+++ b/src/main/resources/templates/search/result.html
@@ -12,7 +12,7 @@
 <div layout:decorator="layout">
     <div layout:fragment="contents">
         <form id="searchForm" method="get" th:action="@{/search}">
-            <input type="text" class="form-control" placeholder="キーワードを入力" name="q" th:value="${query}">
+            <input type="text" class="form-control" placeholder="キーワードを入力" name="q" th:value="${query}" required>
         </form>
 
         <div class="container body">

--- a/src/main/resources/templates/search/result.html
+++ b/src/main/resources/templates/search/result.html
@@ -17,15 +17,19 @@
 
         <div class="container body">
             <table class="table table-condensed">
-                <tbody th:remove="all-but-first" th:each="result : ${articleList}">
-                <tr>
+                <tbody>
+                <tr th:each="result : ${articleList}" th:if="${!articleList.isEmpty()}">
                     <td><img src="http://diamond.jp/mwimgs/7/1/400/img_71c53c1d81500a1cf73a4f543e72413f27838.jpg"
                              height="50"
                              width="100"></td>
                     <td th:text="|${#dates.format(result.releasedAt, 'yyyy年MM月dd日')}に投稿|"></td>
                     <td><h3 th:text="${result.title}"></h3></td>
                 </tr>
+                <p th:if="${articleList.isEmpty() && query.length() > 0}" th:text="|「${query}」に一致する記事は見つかりませんでした。|"></p>
+                <p th:if="${articleList.isEmpty() && query.length() == 0}">検索クエリが設定されていません。</p>
                 </tbody>
+
+
             </table>
         </div>
     </div>


### PR DESCRIPTION
# TODO
- テストケースの作成

# テストケース
## 新規登録周り
- [x] `UserRegisterService.validate(email: String, accountName: String)`でバリデーション処理を実装する
- [x] ユーザー名、Emailのいずれかがユニークではない場合は登録に失敗する
- [x] emailには英数字もしくは_, -しか使えないようにする

### 検索ページ
- [x] 検索ぺーじ、ヘッダーの検索フォームで空の入力ができないようにHTML側でalertをだす
- [x] HTML側の機能を解除した状態で空検索を行なった場合は`検索クエリが設定されていません。`という検索結果をだす
- [x] 検索対象が見つからなかった場合、`「〇〇」に一致する記事は見つかりませんでした。`という検索結果をだす

### ユーザーページ
- [x] headerのユーザーアイコンをクリックするとユーザーページに遷移する

### いいね機能
- [ ] ユーザーは一度しかいいねをつけることができない
いいねをつけている場合 -> 緑
いいねをつけていない場合 -> 白
フロント側ではクリックできないようにcssを設定する disable
サーバーサイドではすでにいいねをつけている場合はそのままスルーする
`SELECT * from user_like_article where article_id = #{articleId} AND user_id = #{userId}`

- [ ] 自分の記事にはいいねをつけることができない
いいねをつけようとしているArticleのuser_idがcurrent_userのidと一致する場合

- [ ] まずは同期通信で行う`/article/like/create`にpostしたあと、Articleの詳細にリダイレクトさせる
- [ ] 非同期通信で処理する


コントローラー側に何を返す
Exception? Boolean?
登録済って表示する？
どんなメッセージを表示する？
bindingResultを返す