### PR TITLE
講座の削除ができる

### DIFF
--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -2,6 +2,8 @@ package com.final.project.Teechear.controller
 
 import com.final.project.Teechear.exception.ResourceNotFoundException
 import com.final.project.Teechear.form.LessonNewForm
+import com.final.project.Teechear.helper.AlertMessage
+import com.final.project.Teechear.helper.AlertMessageType
 import com.final.project.Teechear.service.LessonService
 import com.final.project.Teechear.service.S3Service
 import com.final.project.Teechear.service.UserApplyLessonService
@@ -12,6 +14,7 @@ import org.springframework.validation.BindingResult
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import java.security.Principal
 
 @Controller
@@ -51,9 +54,9 @@ class LessonController(
     fun show(@PathVariable("id") id: Int, model: Model, principal: Principal): String {
         val lesson = try {
             lessonService.select(id)
-        } catch (e : LessonService.LessonServiceException) {
+        } catch (e: LessonService.LessonServiceException) {
             return "error/404.html"
-        } catch (e : LessonService.LessonNotFoundException) {
+        } catch (e: LessonService.LessonNotFoundException) {
             return "error/404.html"
         }
 
@@ -79,9 +82,9 @@ class LessonController(
 
         val lesson = try {
             lessonService.select(id)
-        } catch (e : LessonService.LessonServiceException) {
+        } catch (e: LessonService.LessonServiceException) {
             return "error/404.html"
-        } catch (e : LessonService.LessonNotFoundException) {
+        } catch (e: LessonService.LessonNotFoundException) {
             return "error/404.html"
         }
 
@@ -104,7 +107,10 @@ class LessonController(
     }
 
     @DeleteMapping("/{id}")
-    fun delete(@PathVariable("id") id: Int, principal: Principal): String {
+    fun delete(
+            @PathVariable("id") id: Int,
+            principal: Principal,
+            redirectAttributes: RedirectAttributes): String {
         // lessonに申し込みのユーザーが一人でもいる場合は404.htmlを返す
         if (userApplyLessonService.hasParticipant(id)) {
             return "error/404.html"
@@ -117,6 +123,9 @@ class LessonController(
             return "error/404.html"
         }
 
+        redirectAttributes.addFlashAttribute(
+                "alertMessage",
+                AlertMessage(message = "講座を削除しました", type = AlertMessageType.SUCCESS))
         return "redirect:/user/$currentUserId"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -8,10 +8,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.validation.BindingResult
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.security.Principal
 
@@ -100,5 +97,11 @@ class LessonController(
     fun close(@PathVariable("id") id: Int): String {
         lessonService.close(id)
         return "redirect:/lesson/${id}"
+    }
+
+    @DeleteMapping("/{id}")
+    fun delete(@PathVariable("id") id: Int, principal: Principal): String {
+        val currentUserId = userService.currentUser(principal).id
+        return "redirect:/user/$currentUserId"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -102,6 +102,7 @@ class LessonController(
     @DeleteMapping("/{id}")
     fun delete(@PathVariable("id") id: Int, principal: Principal): String {
         val currentUserId = userService.currentUser(principal).id
+
         return "redirect:/user/$currentUserId"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -114,7 +114,14 @@ class LessonController(
             redirectAttributes: RedirectAttributes): String {
         // lessonに申し込みのユーザーが一人でもいる場合は404.htmlを返す
         if (userApplyLessonService.hasParticipant(id)) {
-            return "error/404.html"
+            redirectAttributes.addFlashAttribute(
+                    "alertMessage",
+                    AlertMessage(
+                            message = "申し込み済みのユーザーが存在するため削除することができません。",
+                            type = AlertMessageType.DANGER
+                    )
+            )
+            return "redirect:/lesson/$id"
         }
 
         val currentUserId = userService.currentUser(principal).id

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -112,7 +112,6 @@ class LessonController(
             @PathVariable("id") id: Int,
             principal: Principal,
             redirectAttributes: RedirectAttributes): String {
-        // lessonに申し込みのユーザーが一人でもいる場合は404.htmlを返す
         if (userApplyLessonService.hasParticipant(id)) {
             redirectAttributes.addFlashAttribute(
                     "alertMessage",

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -102,7 +102,7 @@ class LessonController(
     @DeleteMapping("/{id}")
     fun delete(@PathVariable("id") id: Int, principal: Principal): String {
         val currentUserId = userService.currentUser(principal).id
-
+        lessonService.delete(id, currentUserId)
         return "redirect:/user/$currentUserId"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import java.security.Principal
+import java.sql.SQLException
 
 @Controller
 @RequestMapping("/lesson")
@@ -121,6 +122,15 @@ class LessonController(
             lessonService.delete(id, currentUserId)
         } catch (e: ResourceNotFoundException) {
             return "error/404.html"
+        } catch (e: SQLException) {
+            redirectAttributes.addFlashAttribute(
+                    "alertMessage",
+                    AlertMessage(
+                            message = "講座の削除に失敗しました。時間を置いて再度実行をお願いします。",
+                            type = AlertMessageType.DANGER
+                    )
+            )
+            return "redirect:/lesson/$id"
         }
 
         redirectAttributes.addFlashAttribute(

--- a/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
+++ b/src/main/kotlin/com/final/project/Teechear/controller/LessonController.kt
@@ -1,5 +1,6 @@
 package com.final.project.Teechear.controller
 
+import com.final.project.Teechear.exception.ResourceNotFoundException
 import com.final.project.Teechear.form.LessonNewForm
 import com.final.project.Teechear.service.LessonService
 import com.final.project.Teechear.service.S3Service
@@ -102,7 +103,12 @@ class LessonController(
     @DeleteMapping("/{id}")
     fun delete(@PathVariable("id") id: Int, principal: Principal): String {
         val currentUserId = userService.currentUser(principal).id
-        lessonService.delete(id, currentUserId)
+        try {
+            lessonService.delete(id, currentUserId)
+        } catch (e: ResourceNotFoundException) {
+            return "error/404.html"
+        }
+
         return "redirect:/user/$currentUserId"
     }
 }

--- a/src/main/kotlin/com/final/project/Teechear/mapper/LessonMapper.kt
+++ b/src/main/kotlin/com/final/project/Teechear/mapper/LessonMapper.kt
@@ -25,4 +25,6 @@ interface LessonMapper {
     fun trend(): List<LessonEntity>
 
     fun search(query: String): List<LessonEntity>
+
+    fun delete(id: Int, ownerId: Int): Int
 }

--- a/src/main/kotlin/com/final/project/Teechear/repository/UserApplyLessonRepository.kt
+++ b/src/main/kotlin/com/final/project/Teechear/repository/UserApplyLessonRepository.kt
@@ -1,0 +1,12 @@
+package com.final.project.Teechear.repository
+
+import com.final.project.Teechear.mapper.UserApplyLessonMapper
+import org.springframework.stereotype.Component
+
+@Component
+class UserApplyLessonRepository(private val userApplyLessonMapper: UserApplyLessonMapper) {
+
+    fun hasParticipant(lessonId: Int): Boolean {
+        return userApplyLessonMapper.selectByLessonIds(listOf(lessonId)).count() > 0
+    }
+}

--- a/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
@@ -12,6 +12,7 @@ import com.final.project.Teechear.util.EscapeStringConverter
 import org.springframework.stereotype.Service
 import org.springframework.validation.BindingResult
 import org.springframework.validation.FieldError
+import java.sql.SQLException
 import java.util.*
 
 @Service
@@ -120,11 +121,13 @@ class LessonService(
         return null
     }
 
-    @Throws(ResourceNotFoundException::class)
+    @Throws(ResourceNotFoundException::class, SQLException::class)
     fun delete(id: Int, ownerId: Int) {
         val result = lessonMapper.delete(id, ownerId)
         if (result == 0) {
             throw ResourceNotFoundException("lessonが見つかりません")
+        } else if (result != 1) {
+            throw SQLException()
         }
     }
 

--- a/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
@@ -119,6 +119,10 @@ class LessonService(
         return null
     }
 
+    fun delete(id: Int, ownerId: Int) {
+        val result = lessonMapper.delete(id, ownerId)
+    }
+
     private fun toDomain(lessonEntity: LessonEntity?): Lesson
     {
         if (lessonEntity is LessonEntity) {

--- a/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
@@ -4,6 +4,7 @@ import com.final.project.Teechear.domain.Lesson
 import com.final.project.Teechear.domain.User
 import com.final.project.Teechear.entity.LessonEntity
 import com.final.project.Teechear.entity.UserApplyLessonEntity
+import com.final.project.Teechear.exception.ResourceNotFoundException
 import com.final.project.Teechear.mapper.LessonMapper
 import com.final.project.Teechear.mapper.UserApplyLessonMapper
 import com.final.project.Teechear.form.LessonNewForm
@@ -119,8 +120,12 @@ class LessonService(
         return null
     }
 
+    @Throws(ResourceNotFoundException::class)
     fun delete(id: Int, ownerId: Int) {
         val result = lessonMapper.delete(id, ownerId)
+        if (result == 0) {
+            throw ResourceNotFoundException("lessonが見つかりません")
+        }
     }
 
     private fun toDomain(lessonEntity: LessonEntity?): Lesson

--- a/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
@@ -8,6 +8,7 @@ import com.final.project.Teechear.exception.ResourceNotFoundException
 import com.final.project.Teechear.form.LessonNewForm
 import com.final.project.Teechear.mapper.LessonMapper
 import com.final.project.Teechear.mapper.UserApplyLessonMapper
+import com.final.project.Teechear.repository.UserApplyLessonRepository
 import org.springframework.stereotype.Service
 import org.springframework.validation.BindingResult
 import org.springframework.validation.FieldError
@@ -19,7 +20,8 @@ class LessonService(
         private val dateTimeService: DateTimeService,
         private val lessonMapper: LessonMapper,
         private val userService: UserService,
-        private val userApplyLessonMapper: UserApplyLessonMapper) {
+        private val userApplyLessonMapper: UserApplyLessonMapper,
+        private val userApplyLessonRepository: UserApplyLessonRepository) {
 
     fun createByForm(form: LessonNewForm, userId: Int, imageUrl: String): Int {
         if (form.eventDate is String && form.eventTime is String) {
@@ -131,7 +133,7 @@ class LessonService(
     }
 
     fun isDeletable(lesson: Lesson, currentUserId: Int): Boolean {
-        return lesson.ownerId == currentUserId && userApplyLessonMapper.selectByLessonIds(listOf(lesson.id)).count() == 0
+        return lesson.ownerId == currentUserId && !userApplyLessonRepository.hasParticipant(lesson.id)
     }
 
     private fun toDomain(lessonEntity: LessonEntity?): Lesson

--- a/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
@@ -128,6 +128,10 @@ class LessonService(
         }
     }
 
+    fun isDeletable(lesson: Lesson, currentUserId: Int): Boolean {
+        return lesson.ownerId == currentUserId && userApplyLessonMapper.selectByLessonIds(listOf(lesson.id)).count() == 0
+    }
+
     private fun toDomain(lessonEntity: LessonEntity?): Lesson
     {
         if (lessonEntity is LessonEntity) {

--- a/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/LessonService.kt
@@ -5,10 +5,9 @@ import com.final.project.Teechear.domain.User
 import com.final.project.Teechear.entity.LessonEntity
 import com.final.project.Teechear.entity.UserApplyLessonEntity
 import com.final.project.Teechear.exception.ResourceNotFoundException
+import com.final.project.Teechear.form.LessonNewForm
 import com.final.project.Teechear.mapper.LessonMapper
 import com.final.project.Teechear.mapper.UserApplyLessonMapper
-import com.final.project.Teechear.form.LessonNewForm
-import com.final.project.Teechear.util.EscapeStringConverter
 import org.springframework.stereotype.Service
 import org.springframework.validation.BindingResult
 import org.springframework.validation.FieldError

--- a/src/main/kotlin/com/final/project/Teechear/service/UserApplyLessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/UserApplyLessonService.kt
@@ -1,11 +1,9 @@
 package com.final.project.Teechear.service
 
-import com.final.project.Teechear.domain.Lesson
 import com.final.project.Teechear.domain.ParticipantUser
 import com.final.project.Teechear.entity.UserApplyLessonEntity
 import com.final.project.Teechear.mapper.UserApplyLessonMapper
 import org.springframework.stereotype.Service
-import java.util.*
 
 @Service
 class UserApplyLessonService(private val userApplyLessonMapper: UserApplyLessonMapper, private val lessonService: LessonService, private val userService: UserService) {

--- a/src/main/kotlin/com/final/project/Teechear/service/UserApplyLessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/UserApplyLessonService.kt
@@ -3,17 +3,22 @@ package com.final.project.Teechear.service
 import com.final.project.Teechear.domain.ParticipantUser
 import com.final.project.Teechear.entity.UserApplyLessonEntity
 import com.final.project.Teechear.mapper.UserApplyLessonMapper
+import com.final.project.Teechear.repository.UserApplyLessonRepository
 import org.springframework.stereotype.Service
 
 @Service
-class UserApplyLessonService(private val userApplyLessonMapper: UserApplyLessonMapper, private val lessonService: LessonService, private val userService: UserService) {
+class UserApplyLessonService(
+        private val userApplyLessonMapper: UserApplyLessonMapper,
+        private val lessonService: LessonService,
+        private val userService: UserService,
+        private val userApplyLessonRepository: UserApplyLessonRepository) {
 
     fun selectByLessonIds(lessonIds: List<Int>): List<ParticipantUser> {
         return userApplyLessonMapper.selectByLessonIds(lessonIds).map { toDomain(it) }
     }
 
     fun hasParticipant(lessonId: Int): Boolean {
-        return userApplyLessonMapper.selectByLessonIds(listOf(lessonId)).count() > 0
+        return userApplyLessonRepository.hasParticipant(lessonId)
     }
 
     private fun toDomain(userApplyLessonEntitiy: UserApplyLessonEntity?): ParticipantUser {

--- a/src/main/kotlin/com/final/project/Teechear/service/UserApplyLessonService.kt
+++ b/src/main/kotlin/com/final/project/Teechear/service/UserApplyLessonService.kt
@@ -14,6 +14,10 @@ class UserApplyLessonService(private val userApplyLessonMapper: UserApplyLessonM
         return userApplyLessonMapper.selectByLessonIds(lessonIds).map { toDomain(it) }
     }
 
+    fun hasParticipant(lessonId: Int): Boolean {
+        return userApplyLessonMapper.selectByLessonIds(listOf(lessonId)).count() > 0
+    }
+
     private fun toDomain(userApplyLessonEntitiy: UserApplyLessonEntity?): ParticipantUser {
         if (userApplyLessonEntitiy is UserApplyLessonEntity) {
             val lesson = lessonService.select(userApplyLessonEntitiy.lessonId!!)

--- a/src/main/resources/com/final/project/Teechear/mapper/LessonMapper.xml
+++ b/src/main/resources/com/final/project/Teechear/mapper/LessonMapper.xml
@@ -78,4 +78,8 @@
         ORDER BY
         event_datetime
     </select>
+
+    <delete id="delete">
+        DELETE FROM lesson WHERE id=#{id} AND owner_id=#{ownerId}
+    </delete>
 </mapper>

--- a/src/main/resources/static/css/lesson/show.css
+++ b/src/main/resources/static/css/lesson/show.css
@@ -79,7 +79,12 @@ h2 {
     word-wrap: break-word;
 }
 
-.button-section form {
+.button-section button {
     margin-top: 10px;
-    width: 100%;
+    margin-left: 10px;
+}
+
+.owner-section {
+    display: flex;
+    flex-direction: row;
 }

--- a/src/main/resources/templates/lesson/show.html
+++ b/src/main/resources/templates/lesson/show.html
@@ -34,6 +34,9 @@
                             </form>
 
                             <a th:if="${!canApply}" class="btn btn-primary btn-lg disabled">募集終了</a>
+                            <form id="delete_lesson" th:method="delete" th:action="@{'/lesson/' + ${lesson.id}}">
+                                <button type="submit" class="btn btn-danger submit-button" id="delete-button">削除</button>
+                            </form>
                         </div>
                     </div>
 

--- a/src/main/resources/templates/lesson/show.html
+++ b/src/main/resources/templates/lesson/show.html
@@ -29,7 +29,7 @@
                         <!--マイページの場合-->
                         <div class="owner-section" th:if="${lesson.ownerId == currentUser.id}">
                             <form id="closeLesson" method="post" th:action="@{'/lesson/' + ${lesson.id} + '/close'}"
-                                  onsubmit="return closeConfirm();" th:if="${canApply}">
+                                  onsubmit="return submitConfirm('募集終了にしてもよろしいですか？');" th:if="${canApply}">
                                 <button type="submit" class="btn btn-danger submit-button" id="close-button">募集停止
                                 </button>
                             </form>
@@ -46,14 +46,6 @@
                     </div>
 
                     <script>
-                        function closeConfirm() {
-                            if (window.confirm('募集終了にしてもよろしいですか？')) {
-                                return true;
-                            }
-                            return false;
-                        }
-
-
                         function submitConfirm(message) {
                             if (window.confirm(message)) {
                                 return true;

--- a/src/main/resources/templates/lesson/show.html
+++ b/src/main/resources/templates/lesson/show.html
@@ -30,12 +30,17 @@
                         <div class="owner-section" th:if="${lesson.ownerId == currentUser.id}">
                             <form id="closeLesson" method="post" th:action="@{'/lesson/' + ${lesson.id} + '/close'}"
                                   onsubmit="return closeConfirm();" th:if="${canApply}">
-                                <button type="submit" class="btn btn-danger submit-button" id="close-button">募集停止</button>
+                                <button type="submit" class="btn btn-danger submit-button" id="close-button">募集停止
+                                </button>
                             </form>
 
                             <a th:if="${!canApply}" class="btn btn-primary btn-lg disabled">募集終了</a>
-                            <form id="delete_lesson" th:method="delete" th:action="@{'/lesson/' + ${lesson.id}}">
-                                <button type="submit" class="btn btn-danger submit-button" id="delete-button">削除</button>
+
+                            <!--削除ボタン-->
+                            <form id="delete_lesson" th:method="delete" th:action="@{'/lesson/' + ${lesson.id}}"
+                                  onsubmit="return submitConfirm('本当に削除してもよろしいですか?');">
+                                <button type="submit" class="btn btn-danger submit-button" id="delete-button">削除
+                                </button>
                             </form>
                         </div>
                     </div>
@@ -43,6 +48,14 @@
                     <script>
                         function closeConfirm() {
                             if (window.confirm('募集終了にしてもよろしいですか？')) {
+                                return true;
+                            }
+                            return false;
+                        }
+
+
+                        function submitConfirm(message) {
+                            if (window.confirm(message)) {
                                 return true;
                             }
                             return false;
@@ -76,7 +89,8 @@
                                 <div class="data-title">
                                     <i class="fas fa-clock"></i>目安時間
                                 </div>
-                                <div class="data" th:text="${lesson.estimatedTime == null ? '未定' : lesson.estimatedTime + '分'}"></div>
+                                <div class="data"
+                                     th:text="${lesson.estimatedTime == null ? '未定' : lesson.estimatedTime + '分'}"></div>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/lesson/show.html
+++ b/src/main/resources/templates/lesson/show.html
@@ -34,7 +34,7 @@
                                 </button>
                             </form>
 
-                            <a th:if="${!canApply}" class="btn btn-primary btn-lg disabled">募集終了</a>
+                            <button type="submit" th:if="${!canApply}" class="btn btn-primary submit-button disabled">募集終了</button>
 
                             <!--削除ボタン-->
                             <form id="delete_lesson" th:method="delete" th:action="@{'/lesson/' + ${lesson.id}}"

--- a/src/main/resources/templates/lesson/show.html
+++ b/src/main/resources/templates/lesson/show.html
@@ -38,7 +38,7 @@
 
                             <!--削除ボタン-->
                             <form id="delete_lesson" th:method="delete" th:action="@{'/lesson/' + ${lesson.id}}"
-                                  onsubmit="return submitConfirm('本当に削除してもよろしいですか?');">
+                                  onsubmit="return submitConfirm('本当に削除してもよろしいですか?');" th:if="${isDeletable}">
                                 <button type="submit" class="btn btn-danger submit-button" id="delete-button">削除
                                 </button>
                             </form>


### PR DESCRIPTION
ref https://github.com/MotohiroShiobara/FinalProject/issues/45

# テストケース
- [x] 詳細画面にある削除ボタンを押した際にアラートで「本当に削除してもよろしいですが？」というメッセージが表示され、"OK"を選択するとマイページにリダイレクトされ、"講座を削除しました"というアラートが画面上部に表示される
- [x] 詳細画面にある削除ボタンを押した際にアラートで「本当に削除してもよろしいですが？」というメッセージが表示され、"キャンセル"を選択すると処理はされず、アラートが消える。
- [x] 応募済みのユーザーが一人でもいる場合は削除ボタンは表示されない
- [x] 自分の講座以外を削除しようとした場合は404ページを表示する
- [x] 存在しない講座を削除しようとした場合は404ページを表示する
- [x] 応募済みのユーザーが存在する講座を削除しようとした場合は講座の詳細ページにリダイレクトされ、"申し込み済みのユーザーが存在するため削除することができません。"というアラートが表示される
- [x] 自分の講座ページではない場合は削除ボタンは存在しない。
